### PR TITLE
Add sample request spec for Matthew's login endpoint.

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -6,10 +6,12 @@ class SessionsController < ApplicationController
     if u && u.authenticate(auth_params[:password])
       jwt = Auth.issue({user_id: u.id})
       render status: :ok, json: {jwt: jwt}
+    else
+      render status: 400, json: {}
     end
   end
 
-  private 
+  private
 
   def auth_params
     params.permit(:email, :password)

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,7 +1,0 @@
-FactoryGirl.define do
-  factory :user do
-    name "Learner Larry"
-    email "larry@downtolearn.com"
-    password_digest "deadbeefdeadbeef"
-  end
-end

--- a/spec/requests/login_spec.rb
+++ b/spec/requests/login_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe "User authentication", type: :request do
+  describe "POST /login" do
+    let(:name) { "Larry Learner" }
+    let(:email) { "larry@downtolearn.com" }
+    let(:password) { "test_password" }
+    let!(:user) { User.create!(name: name, email: email, password: password, password_confirmation: password) }
+
+    it "returns a JWT for an existing user with the correct password" do
+      post("/login", params: {email: email, password: password})
+      expect(ActiveSupport::JSON.decode(response.body)).to have_key('jwt')
+      expect(response).to have_http_status(200)
+    end
+
+    it "returns a 400 for an existing user with incorrect password" do
+      post("/login", params: {email: email, password: "the_wrong_password"})
+      expect(ActiveSupport::JSON.decode(response.body)).to eq({})
+      expect(response).to have_http_status(400)
+    end
+
+    it "returns a 400 for a non-existent user" do
+      post("/login", params: {email: "whatisthis", password: "doesn't matter"})
+      expect(ActiveSupport::JSON.decode(response.body)).to eq({})
+      expect(response).to have_http_status(400)
+    end
+  end
+end


### PR DESCRIPTION
At the moment, we can run our specs by `make c`ing into a running `testifi_app` container, and from its shell, running `make test`.