### PR TITLE
Refactor specs.

### DIFF
--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :course do
-    association :teacher, factory: [:user, :teacher], email: "somerandomemail@r.com", google_id: "google_id32948392482"
+    association :teacher, email: "somerandomemail@r.com", google_id: "google_id32948392482"
     course_code "SE 101"
     title "Introduction to Software Engineering"
     description "Taught by P.L. in the Fall of 2016."

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -6,7 +6,7 @@ FactoryGirl.define do
     admin { false }
   end
 
-  trait :teacher do
+  factory :teacher, class: User do
     name { 'P B' }
     email { 'pb@teacher.com' }
     google_id { 't_google_id123' }

--- a/spec/helpers/api_helper.rb
+++ b/spec/helpers/api_helper.rb
@@ -1,6 +1,32 @@
-RSpec.shared_context "with authenticated requests" do
+shared_context "with authenticated requests" do
   def authenticate(user)
     cookies['Authorization'] = 'X'
     allow(Auth).to receive(:decode).and_return({ 'user_id' => user.id })
+  end
+end
+
+shared_examples "an admin-only GET endpoint" do |endpoint|
+  let(:student) { create(:student) }
+
+  before do
+    authenticate(student)
+  end
+
+  it "is inaccessible to student users" do
+    get endpoint
+    expect(response).to have_http_status(403)
+  end
+end
+
+shared_examples "an admin-only POST endpoint" do |endpoint|
+  let(:student) { create(:student) }
+
+  before do
+    authenticate(student)
+  end
+
+  it "is inaccessible to student users" do
+    post endpoint
+    expect(response).to have_http_status(403)
   end
 end

--- a/spec/requests/assignments_spec.rb
+++ b/spec/requests/assignments_spec.rb
@@ -5,13 +5,15 @@ RSpec.describe "Assignments", type: :request do
   include_context "with authenticated requests"
 
   let(:student) { create(:student) }
-  let(:course) { create(:course) }
+  let(:course) { create(:course, students: [student]) }
   let!(:assignment) { create(:assignment, course_id: course.id) }
 
   before(:each) do
     authenticate(student)
-    course.students << student
   end
+
+  # TODO(rwongone): Does anything different happen when a student is not
+  # enrolled in the course? Should a similar restriction apply to teachers?
 
   describe "GET /api/courses/:course_id/assignments" do
     it "returns all assignments in a course as JSON" do


### PR DESCRIPTION
Add shared examples for admin-only endpoints.
Make :teacher a factory, not a trait.
Specs should be self-documenting, removed some comments.