### PR TITLE
Refactor specs to sound more like user stories

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,4 +71,4 @@ node:
 		bash
 
 test:
-	bundle exec rspec
+	docker exec -it testifi_app bash -c 'rspec -fd'

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -51,10 +51,10 @@ ActiveRecord::Schema.define(version: 20170531005146) do
   end
 
   create_table "submissions", force: :cascade do |t|
-    t.bigint "user_id"
-    t.bigint "problem_id"
+    t.bigint "user_id", null: false
+    t.bigint "problem_id", null: false
     t.string "language", null: false
-    t.string "filename"
+    t.string "filename", null: false
     t.string "content_type"
     t.binary "file_contents"
     t.datetime "created_at", null: false

--- a/spec/helpers/api_helper.rb
+++ b/spec/helpers/api_helper.rb
@@ -5,6 +5,10 @@ shared_context "with authenticated requests" do
   end
 end
 
+shared_context "with JSON responses" do
+  let(:json_response) { ActiveSupport::JSON.decode(response.body) }
+end
+
 shared_examples "an admin-only GET endpoint" do |endpoint|
   let(:student) { create(:student) }
 

--- a/spec/requests/assignments_spec.rb
+++ b/spec/requests/assignments_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Assignments", type: :request do
 
   let(:student) { create(:student) }
   let(:teacher) { create(:teacher) }
-  let(:course) { create(:course, students: [student]) }
+  let(:course) { create(:course) }
   let!(:assignment) { create(:assignment, course_id: course.id) }
 
   context "when a teacher is authenticated" do
@@ -33,9 +33,10 @@ RSpec.describe "Assignments", type: :request do
           expect(response.body).to eq(assignment.to_json)
         end
       end
-    end
+    end # teacher teaches course
 
     context "and the teacher does not teach the course" do
+      let(:course) { create(:course) }
       let(:restricted_get_endpoints) do
         [
           "/api/assignments/#{assignment.id}",
@@ -50,7 +51,7 @@ RSpec.describe "Assignments", type: :request do
         end
       end
 
-      # TODO (rwongone): Do we want teachers not to be able to look
+      # TODO(rwongone): Would we want teachers not to be able to look
       # at assignments that don't belong to their courses?
       describe "restricted Assignment endpoints" do
         it "are inaccessible" do
@@ -60,7 +61,7 @@ RSpec.describe "Assignments", type: :request do
           end
         end
       end
-    end
+    end # teacher does not teach course
   end
 
   context "when a student is authenticated" do
@@ -68,23 +69,54 @@ RSpec.describe "Assignments", type: :request do
       authenticate(student)
     end
 
-    describe "GET /api/courses/:course_id/assignments" do
-      it "returns all assignments in a course as JSON" do
-        get "/api/courses/#{course.id}/assignments"
-        expect(response).to have_http_status(200)
-        expect(response.body).to include(assignment.to_json)
-      end
-    end
+    context "and the student is enrolled" do
+      let(:course) { create(:course, students: [student]) }
 
-    describe "GET /api/assignments/:id" do
-      context "when the student is enrolled" do
-        it "returns the Assignment as JSON" do
-          get "/api/assignments/#{assignment.id}"
+      describe "GET /api/courses/:course_id/assignments" do
+        it "returns all assignments in a course as JSON" do
+          get "/api/courses/#{course.id}/assignments"
           expect(response).to have_http_status(200)
-          expect(response.body).to eq(assignment.to_json)
+          expect(response.body).to include(assignment.to_json)
         end
       end
-    end
+
+      describe "GET /api/assignments/:id" do
+        context "when the student is enrolled" do
+          it "returns the Assignment as JSON" do
+            get "/api/assignments/#{assignment.id}"
+            expect(response).to have_http_status(200)
+            expect(response.body).to eq(assignment.to_json)
+          end
+        end
+      end
+    end # enrolled
+
+    context "and the student is not enrolled" do
+      let(:course) { create(:course, students: []) }
+      let(:restricted_get_endpoints) do
+        [
+          "/api/assignments/#{assignment.id}",
+        ]
+      end
+
+      # TODO(rwongone): Require enrollment for a student to view assignments?
+      describe "GET /api/courses/:course_id/assignments" do
+        it "returns all assignments in a course as JSON" do
+          get "/api/courses/#{course.id}/assignments"
+          expect(response).to have_http_status(200)
+          expect(response.body).to include(assignment.to_json)
+        end
+      end
+
+      describe "restricted Assignment endpoints" do
+        it "are inaccessible" do
+          restricted_get_endpoints.each do |endpoint|
+            get endpoint
+            expect(response).to be_forbidden
+          end
+        end
+      end
+    end # not enrolled
   end
 
   describe "POST /api/courses/:id/assignments" do

--- a/spec/requests/assignments_spec.rb
+++ b/spec/requests/assignments_spec.rb
@@ -3,33 +3,87 @@ require 'helpers/rails_helper'
 
 RSpec.describe "Assignments", type: :request do
   include_context "with authenticated requests"
+  include_context "with JSON responses"
 
   let(:student) { create(:student) }
   let(:teacher) { create(:teacher) }
-  let(:course) { create(:course, students: [student], teacher: teacher) }
+  let(:course) { create(:course, students: [student]) }
+  let!(:assignment) { create(:assignment, course_id: course.id) }
 
-  before(:each) do
-    authenticate(student)
-  end
+  context "when a teacher is authenticated" do
+    before(:each) do
+      authenticate(teacher)
+    end
 
-  # TODO(rwongone): Does anything different happen when a student is not
-  # enrolled in the course? Should a similar restriction apply to teachers?
+    context "and the teacher teaches the course" do
+      let(:course) { create(:course, teacher: teacher) }
 
-  describe "GET /api/courses/:course_id/assignments" do
-    let!(:assignment) { create(:assignment, course_id: course.id) }
-    it "returns all assignments in a course as JSON" do
-      get "/api/courses/#{course.id}/assignments"
-      expect(response).to have_http_status(200)
-      expect(response.body).to include(assignment.to_json)
+      describe "GET /api/courses/:course_id/assignments" do
+        it "returns all assignments in a course as JSON" do
+          get "/api/courses/#{course.id}/assignments"
+          expect(response).to have_http_status(200)
+          expect(response.body).to include(assignment.to_json)
+        end
+      end
+
+      describe "GET /api/assignments/:id" do
+        it "returns the Assignment as JSON" do
+          get "/api/assignments/#{assignment.id}"
+          expect(response).to have_http_status(200)
+          expect(response.body).to eq(assignment.to_json)
+        end
+      end
+    end
+
+    context "and the teacher does not teach the course" do
+      let(:restricted_get_endpoints) do
+        [
+          "/api/assignments/#{assignment.id}",
+        ]
+      end
+
+      describe "GET /api/courses/:course_id/assignments" do
+        it "returns all assignments in a course as JSON" do
+          get "/api/courses/#{course.id}/assignments"
+          expect(response).to have_http_status(200)
+          expect(response.body).to include(assignment.to_json)
+        end
+      end
+
+      # TODO (rwongone): Do we want teachers not to be able to look
+      # at assignments that don't belong to their courses?
+      describe "restricted Assignment endpoints" do
+        it "are inaccessible" do
+          restricted_get_endpoints.each do |endpoint|
+            get endpoint
+            expect(response).to be_forbidden
+          end
+        end
+      end
     end
   end
 
-  describe "GET /api/assignments/:id" do
-    let!(:assignment) { create(:assignment, course_id: course.id) }
-    it "returns the Assignment as JSON" do
-      get "/api/assignments/#{assignment.id}"
-      expect(response).to have_http_status(200)
-      expect(response.body).to eq(assignment.to_json)
+  context "when a student is authenticated" do
+    before(:each) do
+      authenticate(student)
+    end
+
+    describe "GET /api/courses/:course_id/assignments" do
+      it "returns all assignments in a course as JSON" do
+        get "/api/courses/#{course.id}/assignments"
+        expect(response).to have_http_status(200)
+        expect(response.body).to include(assignment.to_json)
+      end
+    end
+
+    describe "GET /api/assignments/:id" do
+      context "when the student is enrolled" do
+        it "returns the Assignment as JSON" do
+          get "/api/assignments/#{assignment.id}"
+          expect(response).to have_http_status(200)
+          expect(response.body).to eq(assignment.to_json)
+        end
+      end
     end
   end
 

--- a/spec/requests/assignments_spec.rb
+++ b/spec/requests/assignments_spec.rb
@@ -9,6 +9,12 @@ RSpec.describe "Assignments", type: :request do
   let(:teacher) { create(:teacher) }
   let(:course) { create(:course) }
   let!(:assignment) { create(:assignment, course_id: course.id) }
+  let(:assignment_create_params) do
+    {
+      "name" => "Assignment 1",
+      "description" => "This course introduces students to databases"
+    }
+  end
 
   context "when a teacher is authenticated" do
     before(:each) do
@@ -33,6 +39,19 @@ RSpec.describe "Assignments", type: :request do
           expect(response.body).to eq(assignment.to_json)
         end
       end
+
+      describe "POST /api/courses/:id/assignments" do
+        it "creates an assignment" do
+          post "/api/courses/#{course.id}/assignments", params: assignment_create_params
+          expect(response).to have_http_status(201)
+
+          expect(json_response).to include(
+            "name" => assignment_create_params["name"],
+            "description" => assignment_create_params["description"],
+            "course_id" => course.id
+          )
+        end
+      end
     end # teacher teaches course
 
     context "and the teacher does not teach the course" do
@@ -41,6 +60,11 @@ RSpec.describe "Assignments", type: :request do
         [
           "/api/assignments/#{assignment.id}",
         ]
+      end
+      let(:restricted_post_endpoints) do
+        {
+          "/api/courses/#{course.id}/assignments" => assignment_create_params,
+        }
       end
 
       describe "GET /api/courses/:course_id/assignments" do
@@ -53,20 +77,33 @@ RSpec.describe "Assignments", type: :request do
 
       # TODO(rwongone): Would we want teachers not to be able to look
       # at assignments that don't belong to their courses?
-      describe "restricted Assignment endpoints" do
+      describe "restricted Submission endpoints" do
         it "are inaccessible" do
           restricted_get_endpoints.each do |endpoint|
             get endpoint
             expect(response).to be_forbidden
           end
+
+          restricted_post_endpoints.each do |endpoint, params|
+            post endpoint, params: params
+            expect(response).to be_forbidden
+          end
         end
       end
+
     end # teacher does not teach course
   end
 
   context "when a student is authenticated" do
     before(:each) do
       authenticate(student)
+    end
+
+    describe "POST /api/courses/:id/assignments" do
+      it "is inaccessible whether or not the student is enrolled" do
+        post "/api/courses/#{course.id}/assignments", params: assignment_create_params
+        expect(response).to be_forbidden
+      end
     end
 
     context "and the student is enrolled" do
@@ -117,25 +154,5 @@ RSpec.describe "Assignments", type: :request do
         end
       end
     end # not enrolled
-  end
-
-  describe "POST /api/courses/:id/assignments" do
-    it "allows teachers to post assignments" do
-      authenticate(teacher)
-
-      params = {
-        "name" => "Assignment 1",
-        "description" => "This course introduces students to databases"
-      }
-
-      post "/api/courses/#{course.id}/assignments", params: params, headers: headers
-      expect(response).to have_http_status(201)
-      parsed = ActiveSupport::JSON.decode(response.body)
-      expect(parsed).to include(
-        "name" => params["name"],
-        "description" => params["description"],
-        "course_id" => course.id
-      )
-    end
   end
 end

--- a/spec/requests/courses_spec.rb
+++ b/spec/requests/courses_spec.rb
@@ -3,101 +3,117 @@ require 'helpers/api_helper'
 
 RSpec.describe "Courses", type: :request do
   include_context "with authenticated requests"
+  include_context "with JSON responses"
+
   let(:student) { create(:student) }
   let(:teacher) { create(:teacher) }
   let!(:course) { create(:course) }
-
-  describe "POST /api/courses" do
-    it_behaves_like "an admin-only POST endpoint", "/api/courses"
-
-    it "allows teachers to create a course" do
-      authenticate(teacher)
-
-      params = {
+  let(:default_params) do
+    {
+      "/api/courses" => {
         "course_code" => "CS348",
         "title" => "Introduction to Databases",
-        "description" => "This course introduces students to databases"
+        "description" => "This course introduces students to databases",
       }
-
-      post "/api/courses", params: params, headers: headers
-      expect(response).to have_http_status(201)
-      parsed = ActiveSupport::JSON.decode(response.body)
-      expect(parsed).to include(
-        "course_code" => params["course_code"],
-        "title" => params["title"],
-        "description" => params["description"],
-        "teacher_id" => teacher.id
-      )
-    end
+    }
+  end
+  let(:course_properties) do
+    {
+      "id" => course.id,
+      "course_code" => course.course_code,
+      "title" => course.title,
+      "description" => course.description,
+      "teacher_id" => course.teacher_id,
+    }
   end
 
-  describe "GET /api/courses" do
-    it "returns the Course as JSON for students" do
-      authenticate(student)
+  context "when a teacher is authenticated" do
+    before { authenticate(teacher) }
 
-      get "/api/courses/#{course.id}"
-      expect(response).to have_http_status(200)
-      parsed = ActiveSupport::JSON.decode(response.body)
-      validate_course(parsed, course)
-    end
-  end
+    describe "POST /api/courses" do
+      let(:params) { default_params["/api/courses"] }
+      let(:expected_properties) do
+        {
+          "course_code" => params["course_code"],
+          "title" => params["title"],
+          "description" => params["description"],
+          "teacher_id" => teacher.id,
+        }
+      end
 
-  describe "GET /api/courses/visible" do
-    it "returns no courses when a student is not enrolled" do
-      authenticate(student)
+      it "creates a course" do
+        post "/api/courses", params: params
 
-      get "/api/courses/visible"
-      expect(response).to have_http_status(200)
-      parsed = ActiveSupport::JSON.decode(response.body)
-      expect(parsed).to eq([])
-    end
-
-    context "when a student is enrolled in courses" do
-      let(:course) { create(:course, students: [student]) }
-
-      it "returns those Courses that the student is enrolled in as JSON" do
-        authenticate(student)
-
-        get "/api/courses/visible"
-        expect(response).to have_http_status(200)
-        parsed = ActiveSupport::JSON.decode(response.body)
-        expect(parsed.size).to eq(1)
-        validate_course(parsed[0], course)
+        expect(response).to have_http_status(201)
+        expect(json_response).to include(expected_properties)
       end
     end
 
-
-    it "returns no courses when the teacher is not teaching" do
-      authenticate(teacher)
-
-      get "/api/courses/visible"
-      expect(response).to have_http_status(200)
-      parsed = ActiveSupport::JSON.decode(response.body)
-      expect(parsed).to eq([])
+    describe "GET /api/courses" do
+      it "returns the Course as JSON" do
+        get "/api/courses/#{course.id}"
+        expect(response).to have_http_status(200)
+        expect(json_response).to include(course_properties)
+      end
     end
 
-    context "when the teacher teaches the course" do
-      let(:course) { create(:course, teacher: teacher) }
-
-      it "returns those Courses that the teacher teaches as JSON" do
-        authenticate(teacher)
-
+    describe "GET /api/courses/visible" do
+      it "returns no courses when the teacher is not teaching" do
         get "/api/courses/visible"
         expect(response).to have_http_status(200)
-        parsed = ActiveSupport::JSON.decode(response.body)
-        expect(parsed.size).to eq(1)
-        validate_course(parsed[0], course)
+        expect(json_response).to eq([])
+      end
+
+      context "when the teacher teaches the course" do
+        let(:course) { create(:course, teacher: teacher) }
+
+        it "returns those Courses that the teacher teaches as JSON" do
+          get "/api/courses/visible"
+          expect(response).to have_http_status(200)
+          expect(json_response.size).to eq(1)
+          expect(json_response.first).to include(course_properties)
+        end
       end
     end
   end
 
-  def validate_course(actual, expected)
-    expect(actual).to include(
-      "id" => expected.id,
-      "course_code" => expected.course_code,
-      "title" => expected.title,
-      "description" => expected.description,
-      "teacher_id" => expected.teacher_id
-    )
+  context "when a student is authenticated" do
+    before { authenticate(student) }
+
+    describe "POST /api/courses" do
+      let(:params) { default_params["/api/courses"] }
+
+      it "is inaccessible" do
+        post "/api/courses"
+        expect(response).to be_forbidden
+      end
+    end
+
+    describe "GET /api/courses" do
+      it "returns the Course as JSON" do
+        get "/api/courses/#{course.id}"
+        expect(response).to have_http_status(200)
+        expect(json_response).to include(course_properties)
+      end
+    end
+
+    describe "GET /api/courses/visible" do
+      it "returns no courses when the student is not enrolled in any" do
+        get "/api/courses/visible"
+        expect(response).to have_http_status(200)
+        expect(json_response).to eq([])
+      end
+
+      context "when the student is enrolled in a course" do
+        let(:course) { create(:course, students: [student]) }
+
+        it "returns the Courses that the student is enrolled in" do
+          get "/api/courses/visible"
+          expect(response).to have_http_status(200)
+          expect(json_response.size).to eq(1)
+          expect(json_response.first).to include(course_properties)
+        end
+      end
+    end
   end
 end

--- a/spec/requests/courses_spec.rb
+++ b/spec/requests/courses_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe "Courses", type: :request do
       it "returns the Course as JSON" do
         get "/api/courses/#{course.id}"
         expect(response).to have_http_status(200)
-        expect(json_response).to include(course_properties)
+        expect(response.body).to eq(course.to_json)
       end
     end
 
@@ -93,7 +93,7 @@ RSpec.describe "Courses", type: :request do
       it "returns the Course as JSON" do
         get "/api/courses/#{course.id}"
         expect(response).to have_http_status(200)
-        expect(json_response).to include(course_properties)
+        expect(response.body).to eq(course.to_json)
       end
     end
 

--- a/spec/requests/login_spec.rb
+++ b/spec/requests/login_spec.rb
@@ -2,68 +2,66 @@ require 'helpers/api_helper'
 require 'helpers/rails_helper'
 
 RSpec.describe "User authentication", type: :request do
+  include_context "with JSON responses"
+
   describe "GET /api/users/oauth/google" do
     let(:name) { "Larry Learner" }
     let(:email) { "larry@downtolearn.com" }
     # code is a token that might come back from an auth service like google
-    let(:code) { "ksf32hhkjhhhsf32434sfd" }
+    let(:code) { "google_auth_token_123" }
     # google_id is a permanent user id that might come back from google
-    let(:google_id) { "328472342342" }
+    let(:google_id) { "google_id_123" }
+    let(:g_validator_response) do
+      {
+        "sub" => google_id,
+        "name" => name,
+        "email" => email,
+      }
+    end
+    let(:expected_response) do
+      {
+        "google_id" => google_id,
+        "name" => name,
+        "email" => email,
+      }
+    end
+    let(:validator) { instance_double("GoogleIDToken::Validator") }
+
+    before do
+      allow(GoogleIDToken::Validator).to receive(:new).and_return(validator)
+    end
 
     it "returns a JWT and user info for a new user with a google_id" do
-      validator = instance_double("GoogleIDToken::Validator")
-      expect(GoogleIDToken::Validator).to receive(:new).and_return(validator)
-      expect(validator).to receive(:check).with(code, google_client.id, google_client.id).and_return({
-          "sub"=>google_id,
-          "name"=>name,
-          "email"=>email
-      })
+      expect(validator).to receive(:check).with(code, google_client.id, google_client.id).and_return(g_validator_response)
 
       get("/api/users/oauth/google", params: {code: code})
-      parsed = ActiveSupport::JSON.decode(response.body)
-      expect(parsed['name']).to eq(name)
-      expect(parsed['email']).to eq(email)
-      expect(parsed['google_id']).to eq(google_id)
-      expect(cookies['Authorization']).not_to be_empty
       expect(response).to have_http_status(200)
+      expect(json_response).to include(expected_response)
+      expect(cookies['Authorization']).not_to be_empty
     end
 
     it "returns user info for an existing user with a google_id" do
-      validator = instance_double("GoogleIDToken::Validator")
-      expect(GoogleIDToken::Validator).to receive(:new).and_return(validator).exactly(2)
-      expect(validator).to receive(:check).with(code, google_client.id, google_client.id).and_return({
-          "sub"=>google_id,
-          "name"=>name,
-          "email"=>email
-      }).exactly(2)
+      expect(validator).to receive(:check).with(code, google_client.id, google_client.id).and_return(g_validator_response).twice
 
       get("/api/users/oauth/google", params: {code: code})
-      parsed = ActiveSupport::JSON.decode(response.body)
-      expect(parsed['name']).to eq(name)
-      expect(parsed['email']).to eq(email)
-      expect(parsed['google_id']).to eq(google_id)
+      expect(response).to have_http_status(200)
+      expect(json_response).to include(expected_response)
       expect(cookies['Authorization']).not_to be_empty
-      expect(response).to have_http_status(200)
 
-      first_id = parsed['id']
+      first_id = json_response['id']
 
       get("/api/users/oauth/google", params: {code: code})
-      parsed = ActiveSupport::JSON.decode(response.body)
-      expect(parsed['name']).to eq(name)
-      expect(parsed['email']).to eq(email)
-      expect(parsed['google_id']).to eq(google_id)
-      expect(parsed['id']).to eq(first_id)
       expect(response).to have_http_status(200)
+      expect(json_response).to include(expected_response)
+      expect(json_response['id']).to eq(first_id)
     end
 
     it "returns a 403 for an invalid token" do
-      validator = instance_double("GoogleIDToken::Validator")
-      expect(GoogleIDToken::Validator).to receive(:new).and_return(validator)
       expect(validator).to receive(:check).with(code, google_client.id, google_client.id).and_return(false)
       expect(validator).to receive(:problem).and_return("invalid token")
 
       get("/api/users/oauth/google", params: {code: code})
-      expect(response).to have_http_status(403)
+      expect(response).to be_forbidden
     end
   end
 

--- a/spec/requests/problems_spec.rb
+++ b/spec/requests/problems_spec.rb
@@ -3,29 +3,102 @@ require 'helpers/rails_helper'
 
 RSpec.describe "Problems", type: :request do
   include_context "with authenticated requests"
+  include_context "with JSON responses"
 
   let(:student) { create(:student) }
-  let(:course) { create(:course, students: [student]) }
+  let(:teacher) { create(:teacher) }
+  let(:course) { create(:course) }
   let(:assignment) { create(:assignment, course_id: course.id) }
   let!(:problem) { create(:problem, assignment_id: assignment.id) }
 
-  before(:each) do
-    authenticate(student)
-  end
+  context "when a teacher is authenticated" do
+    before(:each) do
+      authenticate(teacher)
+    end
 
-  describe "GET /api/problems/:id" do
-    it "returns the Problem as JSON" do
-      get "/api/problems/#{problem.id}"
-      expect(response).to have_http_status(200)
-      expect(response.body).to eq(problem.to_json)
+    context "and the teacher teaches the course" do
+      let(:course) { create(:course, teacher: teacher) }
+
+      describe "GET /api/problems/:id" do
+        it "returns the Problem as JSON" do
+          get "/api/problems/#{problem.id}"
+          expect(response).to have_http_status(200)
+          expect(response.body).to eq(problem.to_json)
+        end
+      end
+
+      describe "GET /api/assignments/:assignment_id/problems" do
+        it "returns the all Problems of an Assignment as JSON" do
+          get "/api/assignments/#{assignment.id}/problems"
+          expect(response).to have_http_status(200)
+          expect(response.body).to include(problem.to_json)
+        end
+      end
+    end
+
+    context "and the teacher does not teach the course" do
+      let(:course) { create(:course) }
+      let(:restricted_get_endpoints) do
+        [
+          "/api/problems/#{problem.id}",
+          "/api/assignments/#{assignment.id}/problems",
+        ]
+      end
+
+      describe "restricted Problem endpoints" do
+        it "are inaccessible" do
+          restricted_get_endpoints.each do |endpoint|
+            get endpoint
+            expect(response).to be_forbidden
+          end
+        end
+      end
     end
   end
 
-  describe "GET /api/assignments/:assignment_id/problems" do
-    it "returns the all Problems of an Assignment as JSON" do
-      get "/api/assignments/#{assignment.id}/problems"
-      expect(response).to have_http_status(200)
-      expect(response.body).to include(problem.to_json)
+
+  context "when a student is authenticated" do
+    before(:each) do
+      authenticate(student)
+    end
+
+    context "and the student is enrolled" do
+      let(:course) { create(:course, students: [student]) }
+
+      describe "GET /api/problems/:id" do
+        it "returns the Problem as JSON" do
+          get "/api/problems/#{problem.id}"
+          expect(response).to have_http_status(200)
+          expect(response.body).to eq(problem.to_json)
+        end
+      end
+
+      describe "GET /api/assignments/:assignment_id/problems" do
+        it "returns the all Problems of an Assignment as JSON" do
+          get "/api/assignments/#{assignment.id}/problems"
+          expect(response).to have_http_status(200)
+          expect(response.body).to include(problem.to_json)
+        end
+      end
+    end # student is enrolled
+
+    context "and the student is not enrolled" do
+      let(:course) { create(:course) }
+      let(:restricted_get_endpoints) do
+        [
+          "/api/problems/#{problem.id}",
+          "/api/assignments/#{assignment.id}/problems",
+        ]
+      end
+
+      describe "restricted Problem endpoints" do
+        it "are inaccessible" do
+          restricted_get_endpoints.each do |endpoint|
+            get endpoint
+            expect(response).to be_forbidden
+          end
+        end
+      end
     end
   end
 end

--- a/spec/requests/submissions_spec.rb
+++ b/spec/requests/submissions_spec.rb
@@ -4,63 +4,41 @@ require 'rspec/json_expectations'
 
 RSpec.describe "Submissions", type: :request do
   include_context "with authenticated requests"
+  include_context "with JSON responses"
 
   let(:student) { create(:student) }
-  let(:course) { create(:course, students: [student]) }
+  let(:teacher) { create(:teacher) }
+  let(:course) { create(:course) }
   let(:assignment) { create(:assignment, course_id: course.id) }
   let!(:problem) { create(:problem, assignment_id: assignment.id) }
   let!(:submission) { create(:submission, user_id: student.id, problem_id: problem.id) }
+  let(:uploaded_file) { fixture_file_upload("#{fixture_path}/files/Solution.java") }
 
-  before(:each) do
-    authenticate(student)
-  end
-
-  describe "GET /api/problems/:problem_id/submissions" do
-    let!(:submission2) { create(:submission, user_id: student.id, problem_id: problem.id) }
-    it "returns a list of all of user's Submissions for a Problem" do
-      get "/api/problems/#{problem.id}/submissions"
-      expect(response).to have_http_status(200)
-      expect(response.body).to eq([submission, submission2].to_json)
+  # TODO(rwongone): Currently, we only check if a user is in a course's
+  # list of enrolled students to decide whether the resource is accessible.
+  # We will want to handle Submissions differently for teachers. How will
+  # a teacher submit a canon solution?
+  context "when a teacher is authenticated" do
+    before(:each) do
+      authenticate(teacher)
     end
-  end
 
-  describe "GET /api/submissions/:id" do
-    it "returns the Submission as JSON" do
-      get "/api/submissions/#{submission.id}"
-      expect(response).to have_http_status(200)
-      expect(response.body).to eq(submission.to_json)
-    end
-  end
-
-  describe "POST /api/problems/:problem_id/submissions" do
-    let (:uploaded_file) { fixture_file_upload("#{fixture_path}/files/Solution.java") }
-    let (:params) do
+    let(:submission_params) do
       {
-        user_id: student.id,
+        user_id: teacher.id,
         problem_id: problem.id,
         language: 'java',
         file: uploaded_file,
       }
     end
-    let (:expected_properties) do
-      {
-        user_id: student.id,
-        problem_id: problem.id,
-        language: 'java',
-        filename: 'Solution.java',
-      }
-    end
-
-    it "creates a Submission with the right attributes" do
-      post "/api/problems/#{problem.id}/submissions", params: params
-      expect(response).to have_http_status(201)
-      expect(response.body).to include_json(**expected_properties)
-    end
   end
 
-  describe "POST /api/exec" do
-    let (:uploaded_file) { fixture_file_upload("#{fixture_path}/files/Solution.java") }
-    let (:submission_params) do
+  context "when a student is authenticated" do
+    before(:each) do
+      authenticate(student)
+    end
+
+    let(:submission_params) do
       {
         user_id: student.id,
         problem_id: problem.id,
@@ -69,14 +47,83 @@ RSpec.describe "Submissions", type: :request do
       }
     end
 
-    it "synchronously executes the test case and returns the result" do
-      post "/api/problems/#{problem.id}/submissions", params: submission_params
-      post "/api/exec", params: { id: JSON.parse(response.body)['id'] }
+    context "and the student is enrolled" do
+      let(:course) { create(:course, students: [student]) }
 
-      expect(response).to have_http_status(200)
-      expect(response.body).to include_json(
-        result: /.*/,
-      )
+      describe "GET /api/problems/:problem_id/submissions" do
+        let!(:submission2) { create(:submission, user_id: student.id, problem_id: problem.id) }
+        it "returns a list of all of user's Submissions for a Problem" do
+          get "/api/problems/#{problem.id}/submissions"
+          expect(response).to have_http_status(200)
+          expect(response.body).to eq([submission, submission2].to_json)
+        end
+      end
+
+      describe "GET /api/submissions/:id" do
+        it "returns the Submission as JSON" do
+          get "/api/submissions/#{submission.id}"
+          expect(response).to have_http_status(200)
+          expect(response.body).to eq(submission.to_json)
+        end
+      end
+
+      describe "POST /api/problems/:problem_id/submissions" do
+        let(:expected_properties) do
+          {
+            user_id: student.id,
+            problem_id: problem.id,
+            language: 'java',
+            filename: 'Solution.java',
+          }
+        end
+
+        it "creates a Submission with the right attributes" do
+          post "/api/problems/#{problem.id}/submissions", params: submission_params
+          expect(response).to have_http_status(201)
+          expect(response.body).to include_json(**expected_properties)
+        end
+      end
+
+      describe "POST /api/exec" do
+        it "synchronously executes the test case and returns the result" do
+          post "/api/problems/#{problem.id}/submissions", params: submission_params
+          post "/api/exec", params: { id: JSON.parse(response.body)['id'] }
+
+          expect(response).to have_http_status(200)
+          expect(response.body).to include_json(
+            result: /.*/,
+          )
+        end
+      end
+    end
+
+    context "and the student is not enrolled" do
+      let(:course) { create(:course) }
+      let(:submission) { create(:submission, user_id: student.id, problem_id: problem.id) }
+      let(:restricted_get_endpoints) do
+        [
+          "/api/problems/#{problem.id}/submissions",
+        ]
+      end
+      let(:restricted_post_endpoints) do
+        {
+          "/api/problems/#{problem.id}/submissions" => submission_params,
+        }
+      end
+
+      describe "restricted Submission endpoints" do
+        it "are inaccessible" do
+          restricted_get_endpoints.each do |endpoint|
+            get endpoint
+            expect(response).to be_forbidden
+          end
+
+          restricted_post_endpoints.each do |endpoint, params|
+            post endpoint, params: params
+            expect(response).to be_forbidden
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Organizes specs into two main contexts, either the teacher or the student is authenticated. Within those contexts, the teacher either teaches/does not teach the course, and the student is either enrolled/not enrolled in the course.