### PR TITLE
Add back volume for database

### DIFF
--- a/docker/sys/docker-compose.yml
+++ b/docker/sys/docker-compose.yml
@@ -25,6 +25,10 @@ services:
         image: postgres:9.4
         ports:
             - "5432"
+        volumes:
+            - testifi_data:/var/lib/postgresql/data/testifi
+        environment:
+            - PGDATA=/var/lib/postgresql/data/testifi
     redis:
         container_name: testifi_redis
         image: redis
@@ -56,3 +60,4 @@ services:
             - app
 volumes:
     caddy:
+    testifi_data:


### PR DESCRIPTION
Rollout plan:
backup the db:
docker run -it --rm --network sys_default postgres:9.4 pg_dump -h db -U postgres testifi_production > dump.sql

kill the app:
make stop

start a new db with the volume:
docker run -it --rm -v sys_testifi_data:/var/lib/postgresql/data/testifi -e PGDATA=/var/lib/postgresql/data/testifi -p 5432 postgres:9.4

restore the db:
docker cp dump.sql 00120a5be610:/dump.sql
docker exec -it 00120a5be610 bash
psql -U postgres
create database testifi_production;
psql -U postgres testifi_production < dump.sql